### PR TITLE
Change CircleCI working directory from repo to app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           YATA_API_KEY: "api_key"
           YATA_PROJECT_ID: 1
 
-    working_directory: ~/repo
+    working_directory: ~/app
     steps:
       - checkout
 


### PR DESCRIPTION
It occurred that our CircleCI integration wasn't working. Changed working directory and now it works.