### PR TITLE
Update to translations formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ config :yatapp,
 | download_on_start | Download all translations when app starts | `true` | - | - |
 | json_parser | JSON parser that will be used to parse response from API | `Jason` | - | required |
 | fallback | Fallback to default locale if translation empty. | `false` | optional | - |
-| translations_format | Format you wish to get files in, available for now are (yml, js, json, properties, xml, strings, plist) | `"yml"` | - | optional |
+| translations_format | Format you wish to get files in, available for now are (yml, js, json, properties, xml, xml_escaped, xml_android_resource, strings, plist) | `"yml"` | - | optional |
 | translation_file_parser | Parser that will parse downloaded files | | - | optional |
 | save_to_path | A directory where translations will be saved. | `"priv/locales/"` | - | optional |
 | root | Download with language as a root element of the translation | `false` | - | optional |


### PR DESCRIPTION
Two new versions of XML formats were introduced:
- `xml_escaped` - the same as `xml` but escapes characters like `<`,`>`, `&` and a few others that could break XML formatting;
- `xml_android_resource` - the same as `xml_escaped` but with even more rules to key naming. Specifically, translations key must follow the same rules as Java variable names do due to how string resources are used in Android. This type is capable of outputting partially modified translation keys: `-` and `.` are replaced as `_`, e.g. `this.is.my-key_` will be `this_is_my_key_`.